### PR TITLE
Allow a catch-all listener.

### DIFF
--- a/src/Emitter.php
+++ b/src/Emitter.php
@@ -148,6 +148,9 @@ class Emitter implements EmitterInterface
         $arguments[0] = $event;
         $this->invokeListeners($listeners, $event, $arguments);
 
+        // Trigger Catch-All Listeners
+        $this->invokeListeners($this->getListeners('*'), $event, $arguments);
+
         return $event;
     }
 


### PR DESCRIPTION
This will automatically emit all events to any listener on the `*` event.

Usage:

``` php
<?php

$emitter->addListener('*', function ($event) {
    Logger::debug('Event Triggered: '.$event->getName());
});
```
