### PR TITLE
Docs example incorrectly uses ListenerAbstract

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,9 +53,9 @@ You can create custom listeners.
 
 ```php
 use League\Event\AbstractEvent;
-use League\Event\ListenerAbstract;
+use League\Event\AbstractListener;
 
-class DomainListener extends ListenerAbstract
+class DomainListener extends AbstractListener
 {
     public function handle(AbstractEvent $event)
     {


### PR DESCRIPTION
Docs example for custom listeners incorrectly uses the base class ListenerAbstract. Changed to AbstractListener
