### PR TITLE
Derives an interface from AbstractEvent

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### Added
+
+- EventInterface: an interface is derived from the AbstractEvent class to allow more flexible type hinting and custom implementations. All the code expecting an AbstractEvent now expect an EventInterface implementation, however AbstractEvent covers the most use cases.
+
+
 ## 1.0.0 - 2014-10-09
 
 ### Altered

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ $emitter->removeAllListeners('event.name');
 
 # Usage (Advanced)
 
-You can create custom event types by extending the `AbstractEvent` class.
+You can create custom event types by implementing the `EventInterface` interface. `AbstractEvent` provides a basic abstraction which can be used in most cases.
 
 ```php
 use League\Event\AbstractEvent;
@@ -53,12 +53,12 @@ $emitter->emit(new DomainEvent);
 You can create custom listeners.
 
 ```php
-use League\Event\AbstractEvent;
+use League\Event\EventInterface;
 use League\Event\AbstractListener;
 
 class DomainListener extends AbstractListener
 {
-    public function handle(AbstractEvent $event)
+    public function handle(EventInterface $event)
     {
         // Handle the event.
     }
@@ -107,7 +107,7 @@ $emitter->emit('event', 'param value');
 ```php
 class Listener extends AbstractListener
 {
-	public function handle(AbstractEvent $event, $param = null)
+	public function handle(EventInterface $event, $param = null)
 	{
 		var_dump(func_get_args());
 	}

--- a/spec/League/Event/EventSpec.php
+++ b/spec/League/Event/EventSpec.php
@@ -16,6 +16,7 @@ class EventSpec extends ObjectBehavior
     {
         $this->shouldHaveType('League\Event\Event');
         $this->shouldHaveType('League\Event\AbstractEvent');
+        $this->shouldHaveType('League\Event\EventInterface');
     }
 
     public function it_should_have_a_name()

--- a/spec/League/Event/GeneratorSpec.php
+++ b/spec/League/Event/GeneratorSpec.php
@@ -2,7 +2,7 @@
 
 namespace spec\League\Event;
 
-use League\Event\AbstractEvent;
+use League\Event\EventInterface;
 use PhpSpec\ObjectBehavior;
 
 class GeneratorSpec extends ObjectBehavior
@@ -12,12 +12,12 @@ class GeneratorSpec extends ObjectBehavior
         $this->shouldHaveType('League\Event\Generator');
     }
 
-    public function it_should_accept_an_event_object(AbstractEvent $event)
+    public function it_should_accept_an_event_object(EventInterface $event)
     {
         $this->addEvent($event)->shouldReturn($this);
     }
 
-    public function it_should_release_events(AbstractEvent $event)
+    public function it_should_release_events(EventInterface $event)
     {
         $this->releaseEvents()->shouldHaveCount(0);
         $this->addEvent($event);

--- a/spec/League/Event/OneTimeListenerSpec.php
+++ b/spec/League/Event/OneTimeListenerSpec.php
@@ -4,7 +4,7 @@ namespace spec\League\Event;
 
 use PhpSpec\ObjectBehavior;
 use League\Event\ListenerInterface;
-use League\Event\AbstractEvent;
+use League\Event\EventInterface;
 use League\Event\Emitter;
 
 class OneTimeListenerSpec extends ObjectBehavior
@@ -27,7 +27,7 @@ class OneTimeListenerSpec extends ObjectBehavior
         $this->getWrappedListener()->shouldReturn($this->listener);
     }
 
-    public function it_should_unregister_and_forward_the_handle_call(AbstractEvent $event, Emitter $emitter)
+    public function it_should_unregister_and_forward_the_handle_call(EventInterface $event, Emitter $emitter)
     {
         $event->getName()->willReturn('event');
         $event->getEmitter()->willReturn($emitter);

--- a/src/AbstractEvent.php
+++ b/src/AbstractEvent.php
@@ -2,7 +2,7 @@
 
 namespace League\Event;
 
-abstract class AbstractEvent
+abstract class AbstractEvent implements EventInterface
 {
     /**
      * Has propagation stopped?
@@ -19,11 +19,7 @@ abstract class AbstractEvent
     protected $emitter;
 
     /**
-     * Set the Emitter.
-     *
-     * @param EmitterInterface $emitter
-     *
-     * @return $this
+     * {@inheritdoc}
      */
     public function setEmitter(EmitterInterface $emitter)
     {
@@ -33,9 +29,7 @@ abstract class AbstractEvent
     }
 
     /**
-     * Get the Emitter.
-     *
-     * @return EmitterInterface
+     * {@inheritdoc}
      */
     public function getEmitter()
     {
@@ -43,9 +37,7 @@ abstract class AbstractEvent
     }
 
     /**
-     * Stop event propagation.
-     *
-     * @return $this
+     * {@inheritdoc}
      */
     public function stopPropagation()
     {
@@ -55,9 +47,7 @@ abstract class AbstractEvent
     }
 
     /**
-     * Check weather propagation was stopped.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isPropagationStopped()
     {
@@ -65,9 +55,7 @@ abstract class AbstractEvent
     }
 
     /**
-     * Get the event name.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getName()
     {

--- a/src/CallbackListener.php
+++ b/src/CallbackListener.php
@@ -34,7 +34,7 @@ class CallbackListener implements ListenerInterface
     /**
      * {@inheritdoc}
      */
-    public function handle(AbstractEvent $event)
+    public function handle(EventInterface $event)
     {
         call_user_func_array($this->callback, func_get_args());
     }

--- a/src/Emitter.php
+++ b/src/Emitter.php
@@ -141,13 +141,13 @@ class Emitter implements EmitterInterface
     /**
      * Invoke the listeners for an event.
      *
-     * @param string        $name
-     * @param AbstractEvent $event
-     * @param array         $arguments
+     * @param string         $name
+     * @param EventInterface $event
+     * @param array          $arguments
      *
      * @return void
      */
-    protected function invokeListeners($name, AbstractEvent $event, array $arguments)
+    protected function invokeListeners($name, EventInterface $event, array $arguments)
     {
         $listeners = $this->getListeners($name);
 
@@ -163,7 +163,7 @@ class Emitter implements EmitterInterface
     /**
      * Prepare an event for emitting.
      *
-     * @param string|AbstractEvent $event
+     * @param string|EventInterface $event
      *
      * @return array
      */
@@ -177,13 +177,13 @@ class Emitter implements EmitterInterface
     }
 
     /**
-     * Ensure event input is of type AbstractEvent or convert it.
+     * Ensure event input is of type EventInterface or convert it.
      *
-     * @param string|AbstractEvent $event
+     * @param string|EventInterface $event
      *
      * @throws InvalidArgumentException
      *
-     * @return AbstractEvent
+     * @return EventInterface
      */
     protected function ensureEvent($event)
     {
@@ -191,7 +191,7 @@ class Emitter implements EmitterInterface
             return new Event($event);
         }
 
-        if ( ! $event instanceof AbstractEvent) {
+        if ( ! $event instanceof EventInterface) {
             throw new InvalidArgumentException('Events should be provides as Event instances or string, received type: ' . gettype($event));
         }
 

--- a/src/EmitterInterface.php
+++ b/src/EmitterInterface.php
@@ -85,9 +85,9 @@ interface EmitterInterface
     /**
      * Emit an event.
      *
-     * @param string|AbstractEvent $event
+     * @param string|EventInterface $event
      *
-     * @return AbstractEvent
+     * @return EventInterface
      */
     public function emit($event);
 

--- a/src/EmitterTrait.php
+++ b/src/EmitterTrait.php
@@ -122,9 +122,9 @@ trait EmitterTrait
     /**
      * Emit an event.
      *
-     * @param string|AbstractEvent $event
+     * @param string|EventInterface $event
      *
-     * @return AbstractEvent
+     * @return EventInterface
      */
     public function emit($event)
     {

--- a/src/Event.php
+++ b/src/Event.php
@@ -22,9 +22,7 @@ class Event extends AbstractEvent
     }
 
     /**
-     * Get the event name.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getName()
     {

--- a/src/EventInterface.php
+++ b/src/EventInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace League\Event;
+
+interface EventInterface
+{
+    /**
+     * Set the Emitter.
+     *
+     * @param EmitterInterface $emitter
+     *
+     * @return $this
+     */
+    public function setEmitter(EmitterInterface $emitter);
+
+    /**
+     * Get the Emitter.
+     *
+     * @return EmitterInterface
+     */
+    public function getEmitter();
+
+    /**
+     * Stop event propagation.
+     *
+     * @return $this
+     */
+    public function stopPropagation();
+
+    /**
+     * Check weather propagation was stopped.
+     *
+     * @return bool
+     */
+    public function isPropagationStopped();
+
+    /**
+     * Get the event name.
+     *
+     * @return string
+     */
+    public function getName();
+}

--- a/src/GeneratorInterface.php
+++ b/src/GeneratorInterface.php
@@ -7,16 +7,16 @@ interface GeneratorInterface
     /**
      * Add an event.
      *
-     * @param AbstractEvent $event
+     * @param EventInterface $event
      *
      * @return $this
      */
-    public function addEvent(AbstractEvent $event);
+    public function addEvent(EventInterface $event);
 
     /**
      * Release all the added events.
      *
-     * @return AbstractEvent[]
+     * @return EventInterface[]
      */
     public function releaseEvents();
 }

--- a/src/GeneratorTrait.php
+++ b/src/GeneratorTrait.php
@@ -7,18 +7,18 @@ trait GeneratorTrait
     /**
      * The registered events.
      *
-     * @var AbstractEvent[]
+     * @var EventInterface[]
      */
     protected $events = [];
 
     /**
      * Add an event.
      *
-     * @param AbstractEvent $event
+     * @param EventInterface $event
      *
      * @return $this
      */
-    public function addEvent(AbstractEvent $event)
+    public function addEvent(EventInterface $event)
     {
         $this->events[] = $event;
 
@@ -28,7 +28,7 @@ trait GeneratorTrait
     /**
      * Release all the added events.
      *
-     * @return AbstractEvent[]
+     * @return EventInterface[]
      */
     public function releaseEvents()
     {

--- a/src/ListenerInterface.php
+++ b/src/ListenerInterface.php
@@ -7,11 +7,11 @@ interface ListenerInterface
     /**
      * Handle an event.
      *
-     * @param AbstractEvent $event
+     * @param EventInterface $event
      *
      * @return void
      */
-    public function handle(AbstractEvent $event);
+    public function handle(EventInterface $event);
 
     /**
      * Check weather the listener is the given parameter.

--- a/src/OneTimeListener.php
+++ b/src/OneTimeListener.php
@@ -34,7 +34,7 @@ class OneTimeListener implements ListenerInterface
     /**
      * {@inheritdoc}
      */
-    public function handle(AbstractEvent $event)
+    public function handle(EventInterface $event)
     {
         $name = $event->getName();
         $emitter = $event->getEmitter();

--- a/stubs/Listener.php
+++ b/stubs/Listener.php
@@ -2,12 +2,12 @@
 
 namespace League\Event\Stub;
 
-use League\Event\AbstractEvent;
+use League\Event\EventInterface;
 use League\Event\AbstractListener;
 
 class Listener extends AbstractListener
 {
-    public function handle(AbstractEvent $event)
+    public function handle(EventInterface $event)
     {
         $event->stopPropagation();
     }


### PR DESCRIPTION
Adds an interface based on previous discussions.

Notes:
- Since the interface is derrived from `AbstractEvent` every event is there. I am not sure if set/getEmmitter should as well, but didn't check any code, etc, so might not be right.
- I updated docs/spec where it was possible, however (since my lack of understanding in phpspec) it should be reviewed as well.
- Added it to the readme without version/release date data.

Let me know if I missed something.
