### PR TITLE
Enhancement: Implement LazyListener

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,12 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
+        "container-interop/container-interop": "^1.1",
         "henrikbjorn/phpspec-code-coverage": "~1.0.1",
         "phpspec/phpspec": "^2.2"
+    },
+    "suggest": {
+        "container-interop/container-interop": "For using the LazyListener"
     },
     "autoload": {
         "psr-4": {

--- a/spec/LazyListenerSpec.php
+++ b/spec/LazyListenerSpec.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace spec\League\Event;
+
+use Interop\Container\ContainerInterface;
+use League\Event\EventInterface;
+use League\Event\LazyListener;
+use League\Event\ListenerInterface;
+use League\Event\Stub\ContainerException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * @mixin LazyListener
+ */
+class LazyListenerSpec extends ObjectBehavior
+{
+    /**
+     * @var string
+     */
+    private $alias;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function let(ContainerInterface $container)
+    {
+        $alias = 'foo';
+
+        $this->beConstructedWith($alias, $container);
+
+        $this->alias = $alias;
+        $this->container = $container;
+    }
+
+    public function it_implements_the_listener_interface()
+    {
+        $this->shouldHaveType('League\Event\ListenerInterface');
+    }
+
+    public function it_throws_an_exception_when_container_does_not_provide_listener(EventInterface $event)
+    {
+        $this->container->get($this->alias)->willThrow(new ContainerException());
+
+        $this->shouldThrow('BadMethodCallException')->duringHandle($event);
+    }
+
+    public function it_throws_an_exception_when_listener_is_not_correct_type(EventInterface $event)
+    {
+        $this->container->get($this->alias)->willReturn(new \stdClass());
+
+        $this->shouldThrow('BadMethodCallException')->duringHandle($event);
+    }
+
+    public function it_lets_actual_listener_handle_an_event(EventInterface $event, ListenerInterface $actualListener)
+    {
+        $this->container->get($this->alias)->willReturn($actualListener);
+
+        $actualListener->handle($event)->shouldBeCalled();
+
+        $this->handle($event);
+    }
+
+    public function it_fetches_actual_listener_only_once_when_handling_events(
+        EventInterface $event,
+        ListenerInterface $actualListener
+    ) {
+        $this->container->get($this->alias)->willReturn($actualListener)->shouldBeCalledTimes(1);
+
+        $this->handle($event);
+        $this->handle($event);
+    }
+
+    public function it_identifies_as_itself()
+    {
+        $this->container->get($this->alias)->shouldBeCalledTimes(0);
+
+        $this->isListener($this->getWrappedObject())->shouldReturn(true);
+    }
+
+    public function it_does_not_identify_as_actual_listener_when_it_has_not_been_fetched_yet(ListenerInterface $actualListener)
+    {
+        $this->container->get($this->alias)->shouldBeCalledTimes(0);
+
+        $this->isListener($actualListener)->shouldReturn(false);
+    }
+
+    public function it_identifies_as_actual_listener_when_it_has_been_fetched(EventInterface $event, ListenerInterface $actualListener)
+    {
+        $this->container->get($this->alias)->willReturn($actualListener)->shouldBeCalledTimes(1);
+
+        $this->handle($event);
+
+        $this->isListener($actualListener)->shouldReturn(true);
+    }
+}

--- a/src/LazyListener.php
+++ b/src/LazyListener.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace League\Event;
+
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+
+class LazyListener implements ListenerInterface
+{
+    /**
+     * @var string
+     */
+    private $alias;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var ListenerInterface
+     */
+    private $listener;
+
+    public function __construct($alias, ContainerInterface $container)
+    {
+        $this->alias = $alias;
+        $this->container = $container;
+    }
+
+    public function handle(EventInterface $event)
+    {
+        $this->getListener()->handle($event);
+    }
+
+    /**
+     * @return ListenerInterface
+     */
+    private function getListener()
+    {
+        if ($this->listener === null) {
+            try {
+                $listener = $this->container->get($this->alias);
+            } catch (ContainerException $exception) {
+                throw new \BadMethodCallException(sprintf(
+                    'Could not fetch listener with alias "%s" from container',
+                    $this->alias
+                ));
+            }
+
+            if (!$listener instanceof ListenerInterface) {
+                throw new \BadMethodCallException(sprintf(
+                    'Service with alias "%s" does not implement the ListenerInterface',
+                    $this->alias
+                ));
+            }
+
+            $this->listener = $listener;
+        }
+
+        return $this->listener;
+    }
+
+    public function isListener($listener)
+    {
+        if ($listener instanceof LazyListener) {
+            return $this === $listener;
+        }
+
+        if ($this->listener !== null) {
+            return $this->listener === $listener;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string             $alias
+     * @param ContainerInterface $container
+     * @return static
+     */
+    public static function fromAlias($alias, ContainerInterface $container)
+    {
+        return new static($alias, $container);
+    }
+}

--- a/stubs/ContainerException.php
+++ b/stubs/ContainerException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace League\Event\Stub;
+
+use Interop\Container\Exception;
+
+class ContainerException extends \Exception implements Exception\ContainerException
+{
+}


### PR DESCRIPTION
This PR

* [x] requires `container-interop/container-interop` as a development dependency and suggests its installation
* [x] implements a `LazyListener`, composing an alias and an implementation of `ContainerInterface`, from which it will attempt to fetch the actual listener, and then use it to handle the event

Fixes #59.