### PR TITLE
Add emit batch arguments

### DIFF
--- a/spec/EmitterSpec.php
+++ b/spec/EmitterSpec.php
@@ -82,6 +82,13 @@ class EmitterSpec extends ObjectBehavior
         $this->emit('event')->shouldReturnAnInstanceOf('League\Event\Event');
     }
 
+    public function it_should_allow_you_to_emit_events_with_additional_arguments()
+    {
+        $callback = function ($event, $test, $example) {};
+        $this->addListener('event', $callback)->shouldReturn($this);
+        $this->emit('event', 'test', 'example')->shouldReturnAnInstanceOf('League\Event\Event');
+    }
+
     public function it_should_allow_you_to_emit_event_instances(Event $event)
     {
         $event->setEmitter($this)->shouldBeCalled();
@@ -100,6 +107,13 @@ class EmitterSpec extends ObjectBehavior
         $listener->handle($event)->shouldBeCalled();
         $this->addListener('event', $listener);
         $this->emitBatch([$event])->shouldReturn([$event]);
+    }
+    
+    public function it_should_allow_you_batch_emit_with_additional_arguments(Event $event)
+    {
+        $callback = function ($event, $test, $example) {};
+        $this->addListener('event', $callback)->shouldReturn($this);
+        $this->emitBatch([$event], 'test', 'example')->shouldReturn([$event]);
     }
 
     public function it_should_stop_respond_to_stopping_propagation(Event $event)

--- a/spec/EmitterSpec.php
+++ b/spec/EmitterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\League\Event;
 
+use Exception;
 use League\Event\CallbackListener;
 use League\Event\Event;
 use League\Event\GeneratorInterface;
@@ -84,9 +85,13 @@ class EmitterSpec extends ObjectBehavior
 
     public function it_should_allow_you_to_emit_events_with_additional_arguments()
     {
-        $callback = function ($event, $test, $example) {};
+        $callback = function ($event, $foo, $bar) {
+            if ($foo !== 'foo' || $bar !== 'bar') {
+                throw new Exception('Arguments do not match the expected value.');
+            }
+        };
         $this->addListener('event', $callback)->shouldReturn($this);
-        $this->emit('event', 'test', 'example')->shouldReturnAnInstanceOf('League\Event\Event');
+        $this->emit('event', 'foo', 'bar')->shouldReturnAnInstanceOf('League\Event\Event');
     }
 
     public function it_should_allow_you_to_emit_event_instances(Event $event)
@@ -111,9 +116,18 @@ class EmitterSpec extends ObjectBehavior
     
     public function it_should_allow_you_batch_emit_with_additional_arguments(Event $event)
     {
-        $callback = function ($event, $test, $example) {};
+        $callback = function ($event, $foo, $bar) {
+            if ($foo !== 'foo' || $bar !== 'bar') {
+                throw new Exception('Arguments do not match the expected value.');
+            }
+        };
+        
+        $event->getName()->willReturn('event');
+        $event->setEmitter($this)->shouldBeCalled();
+        $event->isPropagationStopped()->willReturn(false);
+        
         $this->addListener('event', $callback)->shouldReturn($this);
-        $this->emitBatch([$event], 'test', 'example')->shouldReturn([$event]);
+        $this->emitBatch([$event], 'foo', 'bar')->shouldReturn([$event]);
     }
 
     public function it_should_stop_respond_to_stopping_propagation(Event $event)

--- a/src/Emitter.php
+++ b/src/Emitter.php
@@ -180,7 +180,10 @@ class Emitter implements EmitterInterface
         $results = [];
 
         foreach ($events as $event) {
-            $results[] = $this->emit($event);
+            $results[] = call_user_func_array(
+                [$this, 'emit'],
+                [$event] + array_slice(func_get_args(), 1)
+            );
         }
 
         return $results;

--- a/src/Emitter.php
+++ b/src/Emitter.php
@@ -182,7 +182,7 @@ class Emitter implements EmitterInterface
         foreach ($events as $event) {
             $results[] = call_user_func_array(
                 [$this, 'emit'],
-                [$event] + array_slice(func_get_args(), 1)
+                [$event] + array_slice(func_get_args(), 0)
             );
         }
 


### PR DESCRIPTION
Adds the ability to batch emit with arguments.

Here's how I'm handling it with the current version: https://github.com/equip/queue/blob/master/src/Event.php#L31

Also, I don't have much experience with PHPSpec, so I'm not sure if the tests are up to snuff.
