### PR TITLE
Drop buffered events on emit

### DIFF
--- a/src/BufferedEmitter.php
+++ b/src/BufferedEmitter.php
@@ -40,7 +40,7 @@ class BufferedEmitter extends Emitter
     {
         $result = [];
 
-        foreach ($this->bufferedEvents as $event) {
+        while ($event = array_shift($this->bufferedEvents)) {
             $result[] = parent::emit($event);
         }
 


### PR DESCRIPTION
This fixes race conditions in handlers which emit events themselves.

Fixes #79