### PR TITLE
Allow arguments to be passed as references

### DIFF
--- a/src/BufferedEmitter.php
+++ b/src/BufferedEmitter.php
@@ -12,7 +12,7 @@ class BufferedEmitter extends Emitter
     /**
      * @inheritdoc
      */
-    public function emit($event)
+    public function emit($event, &...$args)
     {
         $this->bufferedEvents[] = $event;
 

--- a/src/CallbackListener.php
+++ b/src/CallbackListener.php
@@ -34,9 +34,9 @@ class CallbackListener implements ListenerInterface
     /**
      * @inheritdoc
      */
-    public function handle(EventInterface $event)
+    public function handle(EventInterface $event, &...$args)
     {
-        call_user_func_array($this->callback, func_get_args());
+        call_user_func_array($this->callback, array_merge([$event], $args));
     }
 
     /**

--- a/src/Emitter.php
+++ b/src/Emitter.php
@@ -162,10 +162,11 @@ class Emitter implements EmitterInterface
     /**
      * @inheritdoc
      */
-    public function emit($event)
+    public function emit($event, &...$args)
     {
         list($name, $event) = $this->prepareEvent($event);
-        $arguments = [$event] + func_get_args();
+        $arguments = array_merge([$event], $args);
+
         $this->invokeListeners($name, $event, $arguments);
         $this->invokeListeners('*', $event, $arguments);
 


### PR DESCRIPTION
Currently it is possible to attach arguments to the emitter which will get passed to listeners.
Those arguments get passed by value since internally `func_get_args()` gets used.

It would be very useful to pass arguments by reference to allow listeners to inject stuff into the emitting context.

This pr makes this possible while still be fully compatible.
A listener may now request an argument as reference:

```php
$emitter->addListener('foo', $value, &$anothervalue) {
   $value = 'bar';
   $anothervalue = 'bar';
});

$value="foo";
$anothervalue="foo"
$emitter->emit('foo', $value, $anothervalue);
var_dump($value); //prints string(3) "foo"
var_dump($anothervalue); //prints string(3) "bar"
```