### PR TITLE
travis build php7.3/7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ language: php
 sudo: false
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 install:
   - travis_retry composer install --no-interaction --prefer-source


### PR DESCRIPTION
* php 5.4/5.5 isn't available anymore on travis by default and is eol anyway. 
* Added php 7.3 and php 7.4 stages
