### PR TITLE
Remove state property in PrioritizedListenersForEvent

### DIFF
--- a/src/PrioritizedListenersForEventTest.php
+++ b/src/PrioritizedListenersForEventTest.php
@@ -28,6 +28,8 @@ class PrioritizedListenersForEventTest extends TestCase
         $listener2 = $group->getListeners();
         $this->assertCount(3, $listener2);
         $this->assertEquals([4, 2, 1], self::inspectListener($listener2));
+        $listener3 = $group->getListeners();
+        $this->assertEquals([4, 2, 1], self::inspectListener($listener3));
     }
 
     public static function inspectListener(iterable $listeners): array


### PR DESCRIPTION
containsOneTimeListener should reset to false or `removeOneTimeListeners()` will be called every time when `getListeners()`. 
Reduce state variable will make the code more readable and less bug.