### PR TITLE
Fix PHP 8.4 deprecations for v2, bump minimal version to PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,15 @@ language: php
 sudo: false
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
+  - 8.1
+  - 8.2
+  - 8.3
+  - 8.4
 
 install:
   - travis_retry composer install --no-interaction --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=7.1.0"
     },
     "require-dev": {
         "henrikbjorn/phpspec-code-coverage": "~1.0.1",

--- a/src/EmitterAwareInterface.php
+++ b/src/EmitterAwareInterface.php
@@ -2,21 +2,40 @@
 
 namespace League\Event;
 
-interface EmitterAwareInterface
-{
-    /**
-     * Set the Emitter.
-     *
-     * @param EmitterInterface $emitter
-     *
-     * @return $this
-     */
-    public function setEmitter(EmitterInterface $emitter = null);
+if (PHP_VERSION_ID < 70100) {
+    interface EmitterAwareInterface {
+        /**
+         * Set the Emitter.
+         *
+         * @param EmitterInterface $emitter
+         *
+         * @return $this
+         */
+        public function setEmitter(EmitterInterface $emitter = null);
 
-    /**
-     * Get the Emitter.
-     *
-     * @return EmitterInterface
-     */
-    public function getEmitter();
+        /**
+         * Get the Emitter.
+         *
+         * @return EmitterInterface
+         */
+        public function getEmitter();
+    }
+} else {
+    interface EmitterAwareInterface {
+        /**
+         * Set the Emitter.
+         *
+         * @param EmitterInterface $emitter
+         *
+         * @return $this
+         */
+        public function setEmitter(?EmitterInterface $emitter = null);
+
+        /**
+         * Get the Emitter.
+         *
+         * @return EmitterInterface
+         */
+        public function getEmitter();
+    }
 }

--- a/src/EmitterAwareInterface.php
+++ b/src/EmitterAwareInterface.php
@@ -2,40 +2,21 @@
 
 namespace League\Event;
 
-if (PHP_VERSION_ID < 70100) {
-    interface EmitterAwareInterface {
-        /**
-         * Set the Emitter.
-         *
-         * @param EmitterInterface $emitter
-         *
-         * @return $this
-         */
-        public function setEmitter(EmitterInterface $emitter = null);
+interface EmitterAwareInterface
+{
+    /**
+     * Set the Emitter.
+     *
+     * @param EmitterInterface $emitter
+     *
+     * @return $this
+     */
+    public function setEmitter(?EmitterInterface $emitter = null);
 
-        /**
-         * Get the Emitter.
-         *
-         * @return EmitterInterface
-         */
-        public function getEmitter();
-    }
-} else {
-    interface EmitterAwareInterface {
-        /**
-         * Set the Emitter.
-         *
-         * @param EmitterInterface $emitter
-         *
-         * @return $this
-         */
-        public function setEmitter(?EmitterInterface $emitter = null);
-
-        /**
-         * Get the Emitter.
-         *
-         * @return EmitterInterface
-         */
-        public function getEmitter();
-    }
+    /**
+     * Get the Emitter.
+     *
+     * @return EmitterInterface
+     */
+    public function getEmitter();
 }

--- a/src/EmitterAwareTrait.php
+++ b/src/EmitterAwareTrait.php
@@ -2,77 +2,40 @@
 
 namespace League\Event;
 
-if (PHP_VERSION_ID < 70100) {
-    trait EmitterAwareTrait {
-        /**
-         * The emitter instance.
-         *
-         * @var EmitterInterface|null
-         */
-        protected $emitter;
+trait EmitterAwareTrait
+{
+    /**
+     * The emitter instance.
+     *
+     * @var EmitterInterface|null
+     */
+    protected $emitter;
 
-        /**
-         * Set the Emitter.
-         *
-         * @param EmitterInterface|null $emitter
-         *
-         * @return $this
-         */
-        public function setEmitter(EmitterInterface $emitter = null) {
-            $this->emitter = $emitter;
-
-            return $this;
-        }
-
-        /**
-         * Get the Emitter.
-         *
-         * @return EmitterInterface
-         */
-        public function getEmitter() {
-            if (!$this->emitter) {
-                $this->emitter = new Emitter();
-            }
-
-            return $this->emitter;
-        }
-    }
-} else {
-    trait EmitterAwareTrait
+    /**
+     * Set the Emitter.
+     *
+     * @param EmitterInterface|null $emitter
+     *
+     * @return $this
+     */
+    public function setEmitter(?EmitterInterface $emitter = null)
     {
-        /**
-         * The emitter instance.
-         *
-         * @var EmitterInterface|null
-         */
-        protected $emitter;
+        $this->emitter = $emitter;
 
-        /**
-         * Set the Emitter.
-         *
-         * @param EmitterInterface|null $emitter
-         *
-         * @return $this
-         */
-        public function setEmitter(?EmitterInterface $emitter = null)
-        {
-            $this->emitter = $emitter;
+        return $this;
+    }
 
-            return $this;
+    /**
+     * Get the Emitter.
+     *
+     * @return EmitterInterface
+     */
+    public function getEmitter()
+    {
+        if (! $this->emitter) {
+            $this->emitter = new Emitter();
         }
 
-        /**
-         * Get the Emitter.
-         *
-         * @return EmitterInterface
-         */
-        public function getEmitter()
-        {
-            if (! $this->emitter) {
-                $this->emitter = new Emitter();
-            }
-
-            return $this->emitter;
-        }
+        return $this->emitter;
     }
 }

--- a/src/EmitterAwareTrait.php
+++ b/src/EmitterAwareTrait.php
@@ -2,40 +2,77 @@
 
 namespace League\Event;
 
-trait EmitterAwareTrait
-{
-    /**
-     * The emitter instance.
-     *
-     * @var EmitterInterface|null
-     */
-    protected $emitter;
+if (PHP_VERSION_ID < 70100) {
+    trait EmitterAwareTrait {
+        /**
+         * The emitter instance.
+         *
+         * @var EmitterInterface|null
+         */
+        protected $emitter;
 
-    /**
-     * Set the Emitter.
-     *
-     * @param EmitterInterface|null $emitter
-     *
-     * @return $this
-     */
-    public function setEmitter(EmitterInterface $emitter = null)
-    {
-        $this->emitter = $emitter;
+        /**
+         * Set the Emitter.
+         *
+         * @param EmitterInterface|null $emitter
+         *
+         * @return $this
+         */
+        public function setEmitter(EmitterInterface $emitter = null) {
+            $this->emitter = $emitter;
 
-        return $this;
-    }
-
-    /**
-     * Get the Emitter.
-     *
-     * @return EmitterInterface
-     */
-    public function getEmitter()
-    {
-        if (! $this->emitter) {
-            $this->emitter = new Emitter();
+            return $this;
         }
 
-        return $this->emitter;
+        /**
+         * Get the Emitter.
+         *
+         * @return EmitterInterface
+         */
+        public function getEmitter() {
+            if (!$this->emitter) {
+                $this->emitter = new Emitter();
+            }
+
+            return $this->emitter;
+        }
+    }
+} else {
+    trait EmitterAwareTrait
+    {
+        /**
+         * The emitter instance.
+         *
+         * @var EmitterInterface|null
+         */
+        protected $emitter;
+
+        /**
+         * Set the Emitter.
+         *
+         * @param EmitterInterface|null $emitter
+         *
+         * @return $this
+         */
+        public function setEmitter(?EmitterInterface $emitter = null)
+        {
+            $this->emitter = $emitter;
+
+            return $this;
+        }
+
+        /**
+         * Get the Emitter.
+         *
+         * @return EmitterInterface
+         */
+        public function getEmitter()
+        {
+            if (! $this->emitter) {
+                $this->emitter = new Emitter();
+            }
+
+            return $this->emitter;
+        }
     }
 }


### PR DESCRIPTION
Version 2 of this package supports PHP version 5.4 and higher. In PHP version 7.1 the explicit nullable notation was added and not using it started throwing deprecation warnings in version 8.4.

The package [`league/oauth2-server`](https://github.com/thephpleague/oauth2-server) supports `league/events` v3 starting from `league/oauth2-server` v9. However, due to a [bug](thephpleague/oauth2-server#1456) in `league/oauth2-server` upgrading is blocked for those using the client credentials flow and we're stuck on v8.

Upgrading to PHP 8.4 with v3 is blocked due to `league/oauth2-server`, so upgrading to PHP 8.4 with v2 is the next best thing, but the deprecation warnings are keen on displaying themselves in the response body. They prepend the JSON token returned causing the JSON to become invalid. Although for us it isn't a problem on production, it is quite an annoyance on local development environments since tokens are more often broken than not.

![2025-01-10-135001_1521x346_scrot](https://github.com/user-attachments/assets/ebc8e8dc-7d78-4444-952c-43e1bb67fa91)

This PR is an attempt to fix v2 of this package ~~to stay compatible with PHP 5.4 through PHP 8.4 but~~ without the deprecation warnings being thrown.